### PR TITLE
#4 - Update JPMML-Evaluator dependency to version 1.1.6.

### DIFF
--- a/analytics-ml-pmml/gradle.properties
+++ b/analytics-ml-pmml/gradle.properties
@@ -1,5 +1,5 @@
 slf4jVersion=1.7.7
-jpmmlEvaluatorVersion=1.1.3
+jpmmlEvaluatorVersion=1.1.6
 junitVersion=4.11
 springVersion=4.0.6.RELEASE
 log4jVersion=1.2.17


### PR DESCRIPTION
The update seems to be quite seamlessly. The new [JPMML-Evaluator](https://github.com/jpmml/jpmml-evaluator) Version 1.1.6 contains a number of internal fixes and enhancements. We need to check whether the potentially updated dependencies are aligned with the ones from Spring XD.
