### PR TITLE
URL Cleanup

### DIFF
--- a/analytics-ml-pmml/build.gradle
+++ b/analytics-ml-pmml/build.gradle
@@ -3,11 +3,11 @@ description = 'Spring XD Analytics ML - PMML Support'
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url "http://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url "https://repo.spring.io/release" }
         jcenter()
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
     }
     dependencies {
         classpath("org.springframework.xd:spring-xd-module-plugin:${springXDVersion}")
@@ -35,10 +35,10 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 }
 
 dependencies {

--- a/analytics-ml-pmml/maven.gradle
+++ b/analytics-ml-pmml/maven.gradle
@@ -39,7 +39,7 @@ def customizePom(pom, gradleProject) {
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }

--- a/load-generator-gpfdist-source/build.gradle
+++ b/load-generator-gpfdist-source/build.gradle
@@ -1,11 +1,11 @@
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url "http://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url "https://repo.spring.io/release" }
         jcenter()
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
     }
     dependencies {
 		classpath("org.springframework.xd:spring-xd-module-plugin:1.1.0.RELEASE")
@@ -35,9 +35,9 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" } 
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" } 
 }

--- a/load-generator-source/build.gradle
+++ b/load-generator-source/build.gradle
@@ -1,11 +1,11 @@
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url "http://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url "https://repo.spring.io/release" }
         jcenter()
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
     }
     dependencies {
 		classpath("org.springframework.xd:spring-xd-module-plugin:1.1.0.RELEASE")
@@ -35,9 +35,9 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" } 
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" } 
 }

--- a/load-generator-source/pom.xml
+++ b/load-generator-source/pom.xml
@@ -12,11 +12,11 @@
 	<repositories>
 		<repository>
 			<id>spring-io-release</id>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 		</repository>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 	</repositories>
 </project>

--- a/spring-xd-lang-detector/build.gradle
+++ b/spring-xd-lang-detector/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url "http://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url "https://repo.spring.io/release" }
         jcenter()
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
     }
     dependencies {
         classpath("org.springframework.xd:spring-xd-module-plugin:1.1.0.RELEASE")
@@ -33,11 +33,11 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 }
 
 dependencies {

--- a/spring-xd-lang-detector/pom.xml
+++ b/spring-xd-lang-detector/pom.xml
@@ -28,11 +28,11 @@
     <repositories>
         <repository>
             <id>spring-io-release</id>
-            <url>http://repo.spring.io/release</url>
+            <url>https://repo.spring.io/release</url>
         </repository>
         <repository>
             <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 

--- a/throughput/build.gradle
+++ b/throughput/build.gradle
@@ -1,11 +1,11 @@
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url "http://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url "https://repo.spring.io/release" }
         jcenter()
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
     }
     dependencies {
 		classpath("org.springframework.xd:spring-xd-module-plugin:1.1.0.RELEASE")
@@ -35,9 +35,9 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" } 
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" } 
 }

--- a/videocap/build.gradle
+++ b/videocap/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-snapshot" }
-		maven { url "http://repo.spring.io/release" }
+		maven { url "https://repo.spring.io/plugins-snapshot" }
+		maven { url "https://repo.spring.io/release" }
 		jcenter()
-		maven { url "http://repo.spring.io/snapshot" }
-		maven { url "http://repo.spring.io/milestone" }
+		maven { url "https://repo.spring.io/snapshot" }
+		maven { url "https://repo.spring.io/milestone" }
 	}
 	dependencies { classpath("org.springframework.xd:spring-xd-module-plugin:${springXdVersion}") }
 }
@@ -22,10 +22,10 @@ group = 'org.springframework.xd.videocap'
 description = "Spring XD video capture source module"
 
 repositories {
-	maven { url "http://repo.spring.io/release" }
+	maven { url "https://repo.spring.io/release" }
 	jcenter()
-	maven { url "http://repo.spring.io/snapshot" }
-	maven { url "http://repo.spring.io/milestone" }
+	maven { url "https://repo.spring.io/snapshot" }
+	maven { url "https://repo.spring.io/milestone" }
 }
 
 dependencies {

--- a/xslt-transformer/build.gradle
+++ b/xslt-transformer/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/plugins-snapshot" }
-        maven { url 'http://repo.spring.io/plugins-release' }
-        maven { url "http://repo.spring.io/release" }
-        maven { url "http://repo.spring.io/milestone" }
-        maven { url "http://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/plugins-snapshot" }
+        maven { url 'https://repo.spring.io/plugins-release' }
+        maven { url "https://repo.spring.io/release" }
+        maven { url "https://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
         jcenter()
     }
     dependencies {
@@ -25,11 +25,11 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 repositories {
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 }
 
 dependencies {

--- a/xslt-transformer/pom.xml
+++ b/xslt-transformer/pom.xml
@@ -43,12 +43,12 @@
 	<repositories>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -56,7 +56,7 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -64,7 +64,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://jcenter.bintray.com migrated to:  
  https://jcenter.bintray.com ([https](https://jcenter.bintray.com) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/plugins-snapshot migrated to:  
  https://repo.spring.io/plugins-snapshot ([https](https://repo.spring.io/plugins-snapshot) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance