### PR TITLE
URL Cleanup

### DIFF
--- a/analytics-ml-pmml/src/main/resources/config/analytic-pmml.xml
+++ b/analytics-ml-pmml/src/main/resources/config/analytic-pmml.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xmlns="http://www.springframework.org/schema/integration"
-             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+             xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
     <channel id="input"/>
 

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/interest-rate-simple-linear-regression-1.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/interest-rate-simple-linear-regression-1.pmml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="Linear Regression Model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.3"/>

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-flower-classification-naive-bayes-1.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-flower-classification-naive-bayes-1.pmml.xml
@@ -1,5 +1,5 @@
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="NaiveBayes Model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.4"/>

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-flower-simple-linear-regression-1.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-flower-simple-linear-regression-1.pmml.xml
@@ -1,5 +1,5 @@
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="Linear Regression Model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.3"/>

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-kmeans-clustering-1.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/iris-kmeans-clustering-1.pmml.xml
@@ -1,5 +1,5 @@
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="KMeans cluster model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.4"/>

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/multiple-models.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/multiple-models.pmml.xml
@@ -1,5 +1,5 @@
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="KMeans cluster model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.4"/>

--- a/analytics-ml-pmml/src/test/resources/analytics/pmml/shopping-association-rules-1.pmml.xml
+++ b/analytics-ml-pmml/src/test/resources/analytics/pmml/shopping-association-rules-1.pmml.xml
@@ -1,5 +1,5 @@
-<PMML version="4.1" xmlns="http://www.dmg.org/PMML-4_1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.dmg.org/PMML-4_1 http://www.dmg.org/v4-1/pmml-4-1.xsd">
+<PMML version="4.1" xmlns="/PMML-4_1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="/PMML-4_1/ http://dmg.org/v4-1/pmml-4-1.xsd">
     <Header copyright="Copyright (c) 2014 tom" description="arules association rules model">
         <Extension name="user" value="tom" extender="Rattle/PMML"/>
         <Application name="Rattle/PMML" version="1.4"/>

--- a/load-generator-gpfdist-source/src/main/resources/config/spring-module.xml
+++ b/load-generator-gpfdist-source/src/main/resources/config/spring-module.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:int="http://www.springframework.org/schema/integration"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
     <bean class="org.springframework.xd.loadgenerator.LoadGenerator">
         <constructor-arg name="producers" value="${producers}"/>

--- a/load-generator-source/pom.xml
+++ b/load-generator-source/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.xd.loadgenerator</groupId>
 	<artifactId>load-generator-source</artifactId>
@@ -12,11 +12,11 @@
 	<repositories>
 		<repository>
 			<id>spring-io-release</id>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 		</repository>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 	</repositories>
 </project>

--- a/load-generator-source/src/main/resources/config/spring-module.xml
+++ b/load-generator-source/src/main/resources/config/spring-module.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:int="http://www.springframework.org/schema/integration"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
     <bean class="org.springframework.xd.loadgenerator.LoadGenerator">
         <constructor-arg name="messageCount" value="${messageCount}"/>

--- a/spring-xd-lang-detector/pom.xml
+++ b/spring-xd-lang-detector/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.xd.modules</groupId>
     <artifactId>xd-langdetect</artifactId>
@@ -28,11 +28,11 @@
     <repositories>
         <repository>
             <id>spring-io-release</id>
-            <url>http://repo.spring.io/release</url>
+            <url>https://repo.spring.io/release</url>
         </repository>
         <repository>
             <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 

--- a/spring-xd-lang-detector/src/main/resources/config/spring-module.xml
+++ b/spring-xd-lang-detector/src/main/resources/config/spring-module.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:int="http://www.springframework.org/schema/integration"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
     <bean id="langDetector" class="org.springframework.xd.analytics.linguistics.langdetect.LanguageDetector">
         <property name="inputTextContentPropertyName" value="${inputTextContentPropertyName}"/>

--- a/throughput/src/main/resources/config/spring-module.xml
+++ b/throughput/src/main/resources/config/spring-module.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:int="http://www.springframework.org/schema/integration"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:channel id="input" fixed-subscriber="true" />
 

--- a/videocap/src/main/resources/config/videocap.xml
+++ b/videocap/src/main/resources/config/videocap.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<channel id="output"/>
 

--- a/xslt-transformer/pom.xml
+++ b/xslt-transformer/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>xslt-transformer</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
@@ -43,12 +43,12 @@
 	<repositories>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</repository>
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -56,7 +56,7 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -64,7 +64,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.dmg.org/v4-1/pmml-4-1.xsd (301) with 6 occurrences could not be migrated:  
   ([https](https://www.dmg.org/v4-1/pmml-4-1.xsd) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.dmg.org/PMML-4_1 (301) with 12 occurrences migrated to:  
  /PMML-4_1/ ([https](https://www.dmg.org/PMML-4_1) result IllegalArgumentException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://jcenter.bintray.com with 3 occurrences migrated to:  
  https://jcenter.bintray.com ([https](https://jcenter.bintray.com) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/release with 3 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:9000 with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/beans with 12 occurrences
* http://www.springframework.org/schema/integration with 12 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 15 occurrences