### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 Spring XD Modules
 =================
-This repository contains modules - reusable components for building streams or jobs with [Spring XD](http://projects.spring.io/spring-xd/). The Spring XD distribution includes a number of ready to use  [modules out of the box](http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#available-modules). This repository is intended to supplement the pre-packaged modules with contributions from the user community and the Spring XD team. 
+This repository contains modules - reusable components for building streams or jobs with [Spring XD](https://projects.spring.io/spring-xd/). The Spring XD distribution includes a number of ready to use  [modules out of the box](https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#available-modules). This repository is intended to supplement the pre-packaged modules with contributions from the user community and the Spring XD team. 
 
 Contributions to this repository are subject to the same initial code review and QA processes applied to the main Spring XD code base. However, they are not included in the Spring XD release management and CI processes, as are the pre-packaged modules, and are provided as-is. This means they are manually tested against a specific version of Spring XD and approved updates are merged into the master branch. Additionally, the Spring XD team will manually build and test these against current releases. This policy is subject to change, but at this point this repository should be considered an "incubator". We strongly encourage the Spring XD community to use and contribute to this repository. Furthermore, we envision that this resource will eventually become a vital part of the Spring XD ecosystem. 
 
 
 ## Installing a module
 
-Each module is a self contained component and includes the source code, a general description, and instructions for building the the module with Maven and/or Gradle. In order to use one of these modules, clone this repo, build the module locally, and upload the jar using the spring xd shell `module upload` command. Detailed instructions are included with each project. You will find a good overview of modules and module packaging [here](http://docs.spring.io/spring-xd/docs/current/reference/html/#modules).
+Each module is a self contained component and includes the source code, a general description, and instructions for building the the module with Maven and/or Gradle. In order to use one of these modules, clone this repo, build the module locally, and upload the jar using the spring xd shell `module upload` command. Detailed instructions are included with each project. You will find a good overview of modules and module packaging [here](https://docs.spring.io/spring-xd/docs/current/reference/html/#modules).
 
 ## Updating the Spring XD version
 
-Each module project provides a build script (Maven, Gradle, or both) used to package the module as a jar. The build scripts are configured for a specific Spring XD version. If you intend to use a module with a different Spring XD version, rebuild the module configured for the target version. See the section on [module dependency management](http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#module-dependency-management) in the Spring XD reference for details.
+Each module project provides a build script (Maven, Gradle, or both) used to package the module as a jar. The build scripts are configured for a specific Spring XD version. If you intend to use a module with a different Spring XD version, rebuild the module configured for the target version. See the section on [module dependency management](https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#module-dependency-management) in the Spring XD reference for details.
 
 ## Developing Modules
 
-Read the [Creating a Module](http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#creating-a-module) section in the Spring XD reference guide for a good overview of developing modules. If you want to dive into code, have a look at the example modules in the [spring-xd-samples][Samples] repository as well as the modules here. 
+Read the [Creating a Module](https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#creating-a-module) section in the Spring XD reference guide for a good overview of developing modules. If you want to dive into code, have a look at the example modules in the [spring-xd-samples][Samples] repository as well as the modules here. 
 
 ### Should I provide both Maven and Gradle builds?
 
@@ -23,7 +23,7 @@ Note that many of the [Samples][] provide both Maven and Gradle builds, primaril
 
 ## Contributing to Spring XD
 
-If you would like to contribute to this repository, we encourage contributions via pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please familiarize yourself with the process outlined for contributing to Spring projects here: [Contributor Guidelines](https://github.com/SpringSource/spring-integration/wiki/Contributor-Guidelines).
+If you would like to contribute to this repository, we encourage contributions via pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please familiarize yourself with the process outlined for contributing to Spring projects here: [Contributor Guidelines](https://github.com/SpringSource/spring-integration/wiki/Contributor-Guidelines).
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup). Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.  Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/analytics-ml-pmml/README.adoc
+++ b/analytics-ml-pmml/README.adoc
@@ -3,7 +3,7 @@ Spring XD Analytics ML - PMML
 
 == Introduction
 This  XD processor provides support for real-time evaluation of various machine learning scoring algorithms.
-It is based on the https://github.com/jpmml/jpmml-evaluator[JPMML-Evaluator] library that provides support for a wide range of https://github.com/jpmml/jpmml-evaluator#features[model types] and is interoperable with models exported from http://www.r-project.org/[R], http://rattle.togaware.com/[Rattle], http://www.knime.org/[KNIME], and http://rapid-i.com/content/view/181/190/[RapidMiner].  The JPMML-Evaluator is http://www.gnu.org/licenses/agpl-3.0.html[AGPL] licenced.
+It is based on the https://github.com/jpmml/jpmml-evaluator[JPMML-Evaluator] library that provides support for a wide range of https://github.com/jpmml/jpmml-evaluator#features[model types] and is interoperable with models exported from https://www.r-project.org/[R], https://rattle.togaware.com/[Rattle], https://www.knime.org/[KNIME], and https://rapid-i.com/content/view/181/190/[RapidMiner].  The JPMML-Evaluator is https://www.gnu.org/licenses/agpl-3.0.html[AGPL] licenced.
 
 == Build and Install
 To build, clone this repository. Then cd to `analytics-ml-pmml` and type

--- a/analytics-ml-pmml/docs/src/api/overview.html
+++ b/analytics-ml-pmml/docs/src/api/overview.html
@@ -7,7 +7,7 @@ This document is the API specification for the Spring Data project.
 <!--
 	<p>
 		For further API reference and developer documentation, see the
-		<a href="http://static.springframework.org/spring/docs/2.0.x/reference/index.html" target="_top">Spring Framework reference documentation</a>.
+		<a href="https://docs.spring.io/spring/docs/2.0.x/reference/index.html" target="_top">Spring Framework reference documentation</a>.
 		That documentation contains more detailed, developer-targeted
 		descriptions, with conceptual overviews, definitions of terms,
 		workarounds, and working code examples.
@@ -16,7 +16,7 @@ This document is the API specification for the Spring Data project.
 	<p>
 		If you are interested in commercial training, consultancy and
 		support for the Spring Data Framework,
-		<a href="http://www.gopivotal.com/" target="_top">Pivotal Software, Inc.</a> provides
+		<a href="https://pivotal.io" target="_top">Pivotal Software, Inc.</a> provides
 		such commercial support.
 	</p>
 </div>

--- a/load-generator-gpfdist-source/README.md
+++ b/load-generator-gpfdist-source/README.md
@@ -9,19 +9,19 @@ types.
 
 In order to install the module and run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x ([Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
+* Spring XD version 1.1.x ([Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
 
 ## Building with Maven
 
 	$ mvn package
 
-The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](http://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
+The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](https://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
 
 ## Building with Gradle
 
 	$./gradlew clean test bootRepackage
 
-The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
+The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
 
 ## Using the Custom Module
 

--- a/load-generator-source/README.md
+++ b/load-generator-source/README.md
@@ -9,19 +9,19 @@ types.
 
 In order to install the module and run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x ([Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
+* Spring XD version 1.1.x ([Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
 
 ## Building with Maven
 
 	$ mvn package
 
-The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](http://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
+The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](https://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
 
 ## Building with Gradle
 
 	$./gradlew clean test bootRepackage
 
-The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
+The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
 
 ## Using the Custom Module
 

--- a/spring-xd-lang-detector/README.md
+++ b/spring-xd-lang-detector/README.md
@@ -7,7 +7,7 @@ This is an example of a custom module that uses the [langdetect](https://code.go
 
 In order to install the module run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x [Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started)
+* Spring XD version 1.1.x [Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started)
 
 ## Code Tour
 

--- a/throughput/README.md
+++ b/throughput/README.md
@@ -9,19 +9,19 @@ types.
 
 In order to install the module and run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x ([Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
+* Spring XD version 1.1.x ([Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
 
 ## Building with Maven
 
 	$ mvn package
 
-The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](http://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
+The project's [pom](pom.xml) declares `spring-xd-module-parent` as its parent. This adds the dependencies needed to test the module and also configures the [Spring Boot Maven Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) to package the module as an uber-jar, packaging any dependencies that are not already provided by the Spring XD container. See the [Modules](https://docs.spring.io/spring-xd/docs/current/reference/html/#modules) section in the Spring XD Reference for a more detailed explanation of module class loading.
 
 ## Building with Gradle
 
 	$./gradlew build
 
-The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
+The project's [build.gradle](build.gradle) applies the `spring-xd-module` plugin, providing analagous build and packaging support for gradle. This plugin also applies the [Spring Boot Gradle Plugin](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) as well as the [propdeps plugin](https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin). 
 
 ## Using the Custom Module
 

--- a/videocap/README.md
+++ b/videocap/README.md
@@ -9,13 +9,13 @@ The main use case is to allow to ingest and decode video data into a sequence of
 
 In order to install the module and run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x or later ([Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
+* Spring XD version 1.1.x or later ([Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
 
 ## Building with Gradle
 
 	$./gradlew clean test bootRepackage
 
-This videocap source module depends on the open source computer vision library [opencv](http://opencv.org).
+This videocap source module depends on the open source computer vision library [opencv](https://opencv.org).
 The version of this source module is built upon and tested against is 2.4.9-4. 
 
 For this project, you need to install the opencv Java API support `opencv-2.4.9-4.jar` to the folder `[XD_HOME]/lib` on each xd-container host for this videocap module to work correctly. This is necessary to avoid loading the native opencv library twice into the JVM process. Note that all native libraries are included in the jar and will be extracted automatically if necessary.

--- a/videocap/src/test/resources/samples/sample_video_source.txt
+++ b/videocap/src/test/resources/samples/sample_video_source.txt
@@ -1,1 +1,1 @@
-http://sample-videos.com/
+https://sample-videos.com/

--- a/xslt-transformer/README.md
+++ b/xslt-transformer/README.md
@@ -7,7 +7,7 @@ This is an example of a custom module project that is built and packaged for ins
 
 In order to install the module and run it in your Spring XD installation, you will need to have installed:
 
-* Spring XD version 1.1.x ([Instructions](http://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
+* Spring XD version 1.1.x ([Instructions](https://docs.spring.io/spring-xd/docs/current/reference/html/#getting-started))
 
 ## Code Tour
 
@@ -88,7 +88,7 @@ Since the sample XSLT file transforms the XML record passed in the message to a 
 [pom]: https://github.com/spring-projects/spring-xd-modules/blob/master/xslt-transformer/pom.xml
 [build.gradle]: https://github.com/spring-projects/spring-xd-modules/blob/master/xslt-transformer/build.gradle
 [Spring Integration Java DSL]: https://github.com/spring-projects/spring-integration-java-dsl
-[Spring Boot Maven Plugin]: http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html
-[Spring Boot Gradle Plugin]: http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/build-tool-plugins-gradle-plugin.html
+[Spring Boot Maven Plugin]: https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html
+[Spring Boot Gradle Plugin]: https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/build-tool-plugins-gradle-plugin.html
 [propdeps plugin]: https://github.com/spring-projects/gradle-plugins/tree/master/propdeps-plugin
-[Modules]: http://docs.spring.io/spring-xd/docs/current/reference/html/#modules
+[Modules]: https://docs.spring.io/spring-xd/docs/current/reference/html/#modules

--- a/xslt-transformer/src/test/resources/test.xsl
+++ b/xslt-transformer/src/test/resources/test.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-xmlns:java="http://xml.apache.org/xalan/java"
+xmlns:java="https://xml.apache.org/xalan/java"
     exclude-result-prefixes="java">
 <xsl:output method="text" omit-xml-declaration="yes" indent="no" media-type="text/plain"/>
 <xsl:strip-space elements="*"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/build-tool-plugins-gradle-plugin.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/build-tool-plugins-gradle-plugin.html ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/html/build-tool-plugins-gradle-plugin.html) result 404).
* [ ] http://xml.apache.org/xalan/java (404) with 1 occurrences migrated to:  
  https://xml.apache.org/xalan/java ([https](https://xml.apache.org/xalan/java) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html with 3 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html with 4 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-maven-plugin.html) result 200).
* [ ] http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/ ([https](https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-xd/docs/current/reference/html/ with 11 occurrences migrated to:  
  https://docs.spring.io/spring-xd/docs/current/reference/html/ ([https](https://docs.spring.io/spring-xd/docs/current/reference/html/) result 200).
* [ ] http://static.springframework.org/spring/docs/2.0.x/reference/index.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.0.x/reference/index.html ([https](https://static.springframework.org/spring/docs/2.0.x/reference/index.html) result 200).
* [ ] http://opencv.org with 1 occurrences migrated to:  
  https://opencv.org ([https](https://opencv.org) result 200).
* [ ] http://www.gopivotal.com/ (302) with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://www.gopivotal.com/) result 200).
* [ ] http://projects.spring.io/spring-xd/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-xd/ ([https](https://projects.spring.io/spring-xd/) result 200).
* [ ] http://rattle.togaware.com/ with 1 occurrences migrated to:  
  https://rattle.togaware.com/ ([https](https://rattle.togaware.com/) result 200).
* [ ] http://sample-videos.com/ with 1 occurrences migrated to:  
  https://sample-videos.com/ ([https](https://sample-videos.com/) result 200).
* [ ] http://www.gnu.org/licenses/agpl-3.0.html with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/agpl-3.0.html ([https](https://www.gnu.org/licenses/agpl-3.0.html) result 200).
* [ ] http://www.r-project.org/ with 1 occurrences migrated to:  
  https://www.r-project.org/ ([https](https://www.r-project.org/) result 200).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://rapid-i.com/content/view/181/190/ with 1 occurrences migrated to:  
  https://rapid-i.com/content/view/181/190/ ([https](https://rapid-i.com/content/view/181/190/) result 301).
* [ ] http://www.knime.org/ with 1 occurrences migrated to:  
  https://www.knime.org/ ([https](https://www.knime.org/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:9000 with 2 occurrences
* http://localhost:9393 with 6 occurrences
* http://www.w3.org/1999/XSL/Transform with 1 occurrences