### PR TITLE
URL Cleanup

### DIFF
--- a/analytics-ml-pmml/docs/src/info/license.txt
+++ b/analytics-ml-pmml/docs/src/info/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AbstractPmmlLoader.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AbstractPmmlLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AnalyticPmmlProcessorOptionsMetadata.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AnalyticPmmlProcessorOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AssociationTuplePmmlAnalyticOutputDataMapper.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/AssociationTuplePmmlAnalyticOutputDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/PmmlAnalytic.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/PmmlAnalytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/PmmlLoader.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/PmmlLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/ResourcePmmlLoader.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/ResourcePmmlLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalytic.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalyticInputDataMapper.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalyticInputDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalyticOutputDataMapper.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/TuplePmmlAnalyticOutputDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/package-info.java
+++ b/analytics-ml-pmml/src/main/java/org/springframework/xd/analytics/ml/pmml/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/AbstractPmmlAnalyticTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/AbstractPmmlAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/AssociationAnalysisPmmlAnalyticTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/AssociationAnalysisPmmlAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/KMeansClusteringPmmlAnalyticTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/KMeansClusteringPmmlAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/NaiveBayesClassificationPmmlAnalyticTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/NaiveBayesClassificationPmmlAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/PmmlAnalyticModelTests.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/PmmlAnalyticModelTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/ResourcePmmlLoaderTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/ResourcePmmlLoaderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/SimpleLinearRegressionPmmlAnalyticTest.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/SimpleLinearRegressionPmmlAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/TupleTestUtils.java
+++ b/analytics-ml-pmml/src/test/java/org/springframework/xd/analytics/ml/pmml/TupleTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-gpfdist-source/src/main/java/org/springframework/xd/loadgenerator/LoadGenerator.java
+++ b/load-generator-gpfdist-source/src/main/java/org/springframework/xd/loadgenerator/LoadGenerator.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/load-generator-source/src/main/java/org/springframework/xd/loadgenerator/LoadGenerator.java
+++ b/load-generator-source/src/main/java/org/springframework/xd/loadgenerator/LoadGenerator.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguageDetector.java
+++ b/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguageDetector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguageDetectorOptionsMetadata.java
+++ b/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguageDetectorOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguagePriorityParser.java
+++ b/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/LanguagePriorityParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/TextModel.java
+++ b/spring-xd-lang-detector/src/main/java/org/springframework/xd/analytics/linguistics/langdetect/TextModel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/AbstractLanguageDetectorTests.java
+++ b/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/AbstractLanguageDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/DeterministicLongTextLanguageDetectorTests.java
+++ b/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/DeterministicLongTextLanguageDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/DeterministicShortTextLanguageDetectorTests.java
+++ b/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/DeterministicShortTextLanguageDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/ProbabilisticShortTextLanguageDetectorTests.java
+++ b/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/ProbabilisticShortTextLanguageDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/RestrictedLanguageDetectorTests.java
+++ b/spring-xd-lang-detector/src/test/java/org/springframework/xd/analytics/linguistics/langdetect/RestrictedLanguageDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/throughput/src/main/java/org/springframework/xd/throughput/ThroughputMessageHandler.java
+++ b/throughput/src/main/java/org/springframework/xd/throughput/ThroughputMessageHandler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/videocap/src/main/java/org/springframework/xd/videocap/VideocapChannelAdapter.java
+++ b/videocap/src/main/java/org/springframework/xd/videocap/VideocapChannelAdapter.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/videocap/src/main/java/org/springframework/xd/videocap/VideocapOptionsMetadata.java
+++ b/videocap/src/main/java/org/springframework/xd/videocap/VideocapOptionsMetadata.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/videocap/src/test/java/org/springframework/xd/videocap/VideocapChannelAdapterTests.java
+++ b/videocap/src/test/java/org/springframework/xd/videocap/VideocapChannelAdapterTests.java
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-* http://www.apache.org/licenses/LICENSE-2.0
+* https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xslt-transformer/src/main/java/org/springframework/xd/xslttransformer/XsltTransformerModuleConfig.java
+++ b/xslt-transformer/src/main/java/org/springframework/xd/xslttransformer/XsltTransformerModuleConfig.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xslt-transformer/src/test/java/org/springframework/xd/xslttransformer/XslTransformerTest.java
+++ b/xslt-transformer/src/test/java/org/springframework/xd/xslttransformer/XslTransformerTest.java
@@ -33,7 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/xslt-transformer/src/test/java/org/springframework/xd/xslttransformer/XsltTransformerModulePropertiesTest.java
+++ b/xslt-transformer/src/test/java/org/springframework/xd/xslttransformer/XsltTransformerModulePropertiesTest.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 37 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).